### PR TITLE
rename game namespace to adhere to C# capitalization conventions

### DIFF
--- a/Assets/Prefabs/Canvas UI/ActionButton.prefab
+++ b/Assets/Prefabs/Canvas UI/ActionButton.prefab
@@ -123,7 +123,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 7994476833480249778}
-        m_TargetAssemblyTypeName: Immerse.BfHClient.ActionButton, Assembly-CSharp
+        m_TargetAssemblyTypeName: Immerse.BfhClient.ActionButton, Assembly-CSharp
         m_MethodName: SpawnUnit
         m_Mode: 1
         m_Arguments:

--- a/Assets/Scripts/Game/ActionButton.cs
+++ b/Assets/Scripts/Game/ActionButton.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using UnityEngine.UI;
 
-namespace Immerse.BfHClient
+namespace Immerse.BfhClient
 {
     public class ActionButton : MonoBehaviour
     {

--- a/Assets/Scripts/Game/ActionPopup.cs
+++ b/Assets/Scripts/Game/ActionPopup.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using UnityEngine;
 
-namespace Immerse.BfHClient
+namespace Immerse.BfhClient
 {
     public class ActionPopup : MonoBehaviour
     {

--- a/Assets/Scripts/Game/Country.cs
+++ b/Assets/Scripts/Game/Country.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Immerse.BfHClient
+namespace Immerse.BfhClient
 {
     [System.Serializable]
     public class Country

--- a/Assets/Scripts/Game/GameCanvasController.cs
+++ b/Assets/Scripts/Game/GameCanvasController.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace Immerse.BfHClient
+namespace Immerse.BfhClient
 {
     public class GameCanvasController : MonoBehaviour
     {

--- a/Assets/Scripts/Game/Region.cs
+++ b/Assets/Scripts/Game/Region.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 
-namespace Immerse.BfHClient
+namespace Immerse.BfhClient
 {
 	public class Region : MonoBehaviour
 	{

--- a/Assets/Scripts/Game/RegionColorHandler.cs
+++ b/Assets/Scripts/Game/RegionColorHandler.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace Immerse.BfHClient
+namespace Immerse.BfhClient
 {
 	public class RegionColorHandler
 	{

--- a/Assets/Scripts/Game/RegionLookUp.cs
+++ b/Assets/Scripts/Game/RegionLookUp.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using UnityEngine;
 
-namespace Immerse.BfHClient
+namespace Immerse.BfhClient
 {
 	public class RegionLookUp
 	{

--- a/Assets/Scripts/Game/RegionSelector.cs
+++ b/Assets/Scripts/Game/RegionSelector.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using UnityEngine.EventSystems;
 
-namespace Immerse.BfHClient
+namespace Immerse.BfhClient
 {
 	public class RegionSelector : MonoBehaviour
 	{

--- a/Assets/Scripts/Game/RegionSelectorDebugger.cs
+++ b/Assets/Scripts/Game/RegionSelectorDebugger.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace Immerse.BfHClient
+namespace Immerse.BfhClient
 {
 	public class RegionSelectorDebugger : MonoBehaviour
 	{

--- a/Assets/Scripts/Game/SerializableRegion.cs
+++ b/Assets/Scripts/Game/SerializableRegion.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Immerse.BfHClient
+namespace Immerse.BfhClient
 {
 	[Serializable]
 	public class SerializableRegion

--- a/Assets/Scripts/Scripts.asmdef
+++ b/Assets/Scripts/Scripts.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "Scripts",
-    "rootNamespace": "Immerse.BfHClient",
+    "rootNamespace": "Immerse.BfhClient",
     "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Scripts/UI/JoinLobbyUIController.cs
+++ b/Assets/Scripts/UI/JoinLobbyUIController.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace Immerse.BfHClient.UI
+namespace Immerse.BfhClient.UI
 {
     public class JoinLobbyUIController : MonoBehaviour
     {

--- a/Assets/Scripts/UI/MainMenuUIController.cs
+++ b/Assets/Scripts/UI/MainMenuUIController.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace Immerse.BfHClient.UI
+namespace Immerse.BfhClient.UI
 {
     public class MainMenuUIController : MonoBehaviour
     {

--- a/Assets/Scripts/UI/SceneController.cs
+++ b/Assets/Scripts/UI/SceneController.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-namespace Immerse.BfHClient.UI
+namespace Immerse.BfhClient.UI
 {
     public class SceneController : MonoBehaviour
     {

--- a/Assets/Tests/EditMode/EditMode.asmdef
+++ b/Assets/Tests/EditMode/EditMode.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "EditMode",
-    "rootNamespace": "Immerse.BfHClient.EditTests",
+    "rootNamespace": "Immerse.BfhClient.EditTests",
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",

--- a/Assets/Tests/EditMode/JsonDeserializationTests.cs
+++ b/Assets/Tests/EditMode/JsonDeserializationTests.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Immerse.BfHClient.EditTests
+namespace Immerse.BfhClient.EditTests
 {
     public class JsonDeserializationTests
     {

--- a/Assets/Tests/EditMode/ReflectionExtensions.cs
+++ b/Assets/Tests/EditMode/ReflectionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
-namespace Immerse.BfHClient.EditTests
+namespace Immerse.BfhClient.EditTests
 {
 	public static class ReflectionExtensions {
 		public static T GetFieldValue<T>(this object obj, string name) {

--- a/Assets/Tests/PlayMode/PlayMode.asmdef
+++ b/Assets/Tests/PlayMode/PlayMode.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "PlayMode",
-    "rootNamespace": "Immerse.BfHClient.PlayTests",
+    "rootNamespace": "Immerse.BfhClient.PlayTests",
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",

--- a/ProjectSettings/EditorSettings.asset
+++ b/ProjectSettings/EditorSettings.asset
@@ -17,7 +17,7 @@ EditorSettings:
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 4
   m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef;asmref;rsp
-  m_ProjectGenerationRootNamespace: Immerse.BfHClient
+  m_ProjectGenerationRootNamespace: Immerse.BfhClient
   m_EnableTextureStreamingInEditMode: 1
   m_EnableTextureStreamingInPlayMode: 1
   m_AsyncShaderCompilation: 1


### PR DESCRIPTION
### Changes

- rename namespace `Immerse.BfHClient` -> `Immerse.BfhClient`, following [C# capitalization conventions](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions)