### PR TITLE
fix namespace of tests

### DIFF
--- a/Assets/Tests/EditMode/EditMode.asmdef
+++ b/Assets/Tests/EditMode/EditMode.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "EditMode",
-    "rootNamespace": "Immerse.BfhClient.EditTests",
+    "rootNamespace": "Immerse.BfhClient",
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",

--- a/Assets/Tests/EditMode/JsonDeserializationTests.cs
+++ b/Assets/Tests/EditMode/JsonDeserializationTests.cs
@@ -1,8 +1,9 @@
 using System.Collections.Generic;
+using Immerse.BfhClient.Game;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Immerse.BfhClient.EditTests
+namespace Immerse.BfhClient.Tests.EditMode
 {
     public class JsonDeserializationTests
     {

--- a/Assets/Tests/EditMode/ReflectionExtensions.cs
+++ b/Assets/Tests/EditMode/ReflectionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
-namespace Immerse.BfhClient.EditTests
+namespace Immerse.BfhClient.Tests.EditMode
 {
 	public static class ReflectionExtensions {
 		public static T GetFieldValue<T>(this object obj, string name) {

--- a/Assets/Tests/PlayMode/PlayMode.asmdef
+++ b/Assets/Tests/PlayMode/PlayMode.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "PlayMode",
-    "rootNamespace": "Immerse.BfhClient.PlayTests",
+    "rootNamespace": "Immerse.BfhClient",
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",


### PR DESCRIPTION
### Changes

- change namespaces of tests to satisfy Rider warnings
- add missing `using` directive for `Immerse.BfhClient.Game` in test