### PR TITLE
api: add message types

### DIFF
--- a/Assets/Scripts/Api.meta
+++ b/Assets/Scripts/Api.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cacfa0b4e5215f44da9734ec4d38f0c5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Api/GameTypes.meta
+++ b/Assets/Scripts/Api/GameTypes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f4ebd109c3b1da948abe2055c515e055
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Api/GameTypes/GameTypes.cs
+++ b/Assets/Scripts/Api/GameTypes/GameTypes.cs
@@ -1,0 +1,209 @@
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace Immerse.BfhClient.Api.GameTypes
+{
+    /// <summary>
+    /// Valid values for a player unit's type.
+    /// </summary>
+    public static class UnitType
+    {
+        /// <summary>
+        /// A land unit that gets a +1 modifier in battle.
+        /// </summary>
+        public const string Footman = "footman";
+
+        /// <summary>
+        /// A land unit that moves 2 areas at a time.
+        /// </summary>
+        public const string Horse = "horse";
+
+        /// <summary>
+        /// A unit that can move into sea areas and coastal areas.
+        /// </summary>
+        public const string Ship = "ship";
+
+        /// <summary>
+        /// A land unit that instantly conquers neutral castles, and gets a +1 modifier in attacks on castles.
+        /// </summary>
+        public const string Catapult = "catapult";
+    }
+
+    /// <summary>
+    /// Valid values for a player-submitted order's type.
+    /// </summary>
+    public static class OrderType
+    {
+        /// <summary>
+        /// An order for a unit to move from one area to another.
+        /// Includes internal moves in winter.
+        /// </summary>
+        public const string Move = "move";
+
+        /// <summary>
+        /// An order for a unit to support battle in an adjacent area.
+        /// </summary>
+        public const string Support = "support";
+
+        /// <summary>
+        /// For ship unit at sea: an order to transport a land unit across the sea.
+        /// </summary>
+        public const string Transport = "transport";
+
+        /// <summary>
+        /// For land unit in unconquered castle area: an order to besiege the castle.
+        /// </summary>
+        public const string Besiege = "besiege";
+
+        /// <summary>
+        /// For player-controlled area in winter: an order for what type of unit to build in the area.
+        /// </summary>
+        public const string Build = "build";
+    }
+
+    /// <summary>
+    /// An order submitted by a player for one of their units in a given round.
+    /// </summary>
+    public readonly struct Order
+    {
+        /// <summary>
+        /// The type of order submitted. Restricted by unit type and area.
+        /// Can only be of the constants defined in <see cref="OrderType"/>.
+        /// </summary>
+        [NotNull] public readonly string Type;
+
+        /// <summary>
+        /// The player submitting the order.
+        /// </summary>
+        [NotNull] public readonly string Player;
+
+        /// <summary>
+        /// Name of the area where the order is placed.
+        /// </summary>
+        [NotNull] public readonly string From;
+
+        /// <summary>
+        /// For move and support orders: name of destination area.
+        /// </summary>
+        [CanBeNull] public readonly string To;
+
+        /// <summary>
+        /// For move orders: name of DangerZone the order tries to pass through, if any.
+        /// </summary>
+        [CanBeNull] public readonly string Via;
+
+        /// <summary>
+        /// For build orders: type of unit to build.
+        /// Can only be of the constants defined in <see cref="UnitType"/>.
+        /// </summary>
+        [CanBeNull] public readonly string Build;
+    }
+
+    /// <summary>
+    /// Results of a battle from conflicting move orders, an attempt to conquer a neutral area,
+    /// or an attempt to cross a danger zone.
+    /// </summary>
+    public readonly struct Battle
+    {
+        /// <summary>
+        /// The dice and modifier results of the battle.
+        /// If length is one, the battle was a neutral conquer attempt.
+        /// If length is more than one, the battle was between players.
+        /// </summary>
+        [NotNull] public readonly List<Result> Results;
+
+        /// <summary>
+        /// In case of danger zone crossing: name of the danger zone.
+        /// </summary>
+        [CanBeNull] public readonly string DangerZone;
+    }
+
+    /// <summary>
+    /// Dice and modifier result for a battle.
+    /// </summary>
+    public readonly struct Result
+    {
+        /// <summary>
+        /// The sum of the dice roll and modifiers.
+        /// </summary>
+        public readonly int Total;
+
+        /// <summary>
+        /// The modifiers comprising the result, including the dice roll.
+        /// </summary>
+        [NotNull] public readonly List<Modifier> Parts;
+
+        /// <summary>
+        /// If result of a move order to the battle: the move order in question.
+        /// </summary>
+        [CanBeNull] public readonly Order? Move;
+
+        /// <summary>
+        /// If result of a defending unit in an area: the name of the area.
+        /// </summary>
+        [CanBeNull] public readonly string DefenderArea;
+    }
+
+    /// <summary>
+    /// Valid values for a result modifier's type.
+    /// </summary>
+    public static class ModifierType
+    {
+        /// <summary>
+        /// Bonus from a random dice roll.
+        /// </summary>
+        public const string Dice = "dice";
+
+        /// <summary>
+        /// Bonus for the type of unit.
+        /// </summary>
+        public const string Unit = "unit";
+
+        /// <summary>
+        /// Penalty for attacking a neutral or defended forested area.
+        /// </summary>
+        public const string Forest = "forest";
+
+        /// <summary>
+        /// Penalty for attacking a neutral or defended castle area.
+        /// </summary>
+        public const string Castle = "castle";
+
+        /// <summary>
+        /// Penalty for attacking across a river, from the sea, or across a transport.
+        /// </summary>
+        public const string Water = "water";
+
+        /// <summary>
+        /// Bonus for attacking across a danger zone and surviving.
+        /// </summary>
+        public const string Surprise = "surprise";
+
+        /// <summary>
+        /// Bonus from supporting player in a battle.
+        /// </summary>
+        public const string Support = "support";
+    }
+
+    /// <summary>
+    /// A typed number that adds to a player's result in a battle.
+    /// </summary>
+    public readonly struct Modifier
+    {
+        /// <summary>
+        /// The source of the modifier.
+        /// Can only be of the constants defined in <see cref="ModifierType"/>.
+        /// </summary>
+        [NotNull] public readonly string Type;
+
+        /// <summary>
+        /// The positive or negative number that modifies the result total.
+        /// </summary>
+        public readonly int Value;
+
+        /// <summary>
+        /// If modifier was from a support: the supporting player.
+        /// </summary>
+        [CanBeNull] public readonly string SupportingPlayer;
+    }
+}

--- a/Assets/Scripts/Api/GameTypes/GameTypes.cs.meta
+++ b/Assets/Scripts/Api/GameTypes/GameTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa8c02cfb04273346bbc9278da617718
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Api/Messages.meta
+++ b/Assets/Scripts/Api/Messages.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 920399b4bdc87e44ba000880baffcf44
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Api/Messages/GameMessages.cs
+++ b/Assets/Scripts/Api/Messages/GameMessages.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+using Immerse.BfhClient.Api.GameTypes;
+using JetBrains.Annotations;
+
+namespace Immerse.BfhClient.Api.Messages
+{
+    /// <summary>
+    /// Message sent from server when asking a supporting player who to support in an embattled area.
+    /// </summary>
+    public readonly struct SupportRequestMsg
+    {
+        /// <summary>
+        /// The area from which support is asked, where the asked player should have a support order.
+        /// </summary>
+        [NotNull] public readonly string SupportingArea;
+
+        /// <summary>
+        /// List of possible players to support in the battle.
+        /// </summary>
+        [NotNull] public readonly List<string> SupportablePlayers;
+    }
+
+    /// <summary>
+    /// Message sent from server to client to signal that client should submit orders.
+    /// </summary>
+    public readonly struct OrderRequestMsg
+    { }
+
+    /// <summary>
+    /// Message sent from server to all clients when valid orders are received from all players.
+    /// </summary>
+    public readonly struct OrdersReceivedMsg
+    {
+        [NotNull] public readonly Dictionary<string, List<Order>> PlayerOrders;
+    }
+
+    /// <summary>
+    /// Message sent from server to all clients when valid orders are received from a player.
+    /// Used to show who the server is waiting for.
+    /// </summary>
+    public readonly struct OrdersConfirmationMsg
+    {
+        [NotNull] public readonly string Player;
+    }
+
+    /// <summary>
+    /// Message sent from server to all clients when a battle result is calculated.
+    /// </summary>
+    public readonly struct BattleResultsMsg
+    {
+        [NotNull] public readonly List<Battle> Battles;
+    }
+
+    /// <summary>
+    /// Message sent from server to all clients when the game is won.
+    /// </summary>
+    public readonly struct WinnerMsg
+    {
+        /// <summary>
+        /// Player tag of the game's winner.
+        /// </summary>
+        [NotNull] public readonly string Winner;
+    }
+
+    /// <summary>
+    /// Message sent from client when submitting orders.
+    /// </summary>
+    public readonly struct SubmitOrdersMsg
+    {
+        /// <summary>
+        /// List of submitted orders.
+        /// </summary>
+        [NotNull] public readonly List<Order> Orders;
+    }
+
+    /// <summary>
+    /// Message sent from client when declaring who to support with their support order.
+    /// Forwarded by server to all clients to show who were given support.
+    /// </summary>
+    public readonly struct GiveSupportMsg
+    {
+        /// <summary>
+        /// Name of the area in which the support order is placed.
+        /// </summary>
+        [NotNull] public readonly string SupportingArea;
+
+        /// <summary>
+        /// ID of the player in the destination area to support.
+        /// Null if none were supported.
+        /// </summary>
+        [CanBeNull] public readonly string SupportedPlayer;
+    }
+
+    /// <summary>
+    /// Message passed from the client during winter council voting.
+    /// Used for the throne expansion.
+    /// </summary>
+    public readonly struct WinterVoteMsg
+    {
+        /// <summary>
+        /// ID of the player that the submitting player votes for.
+        /// </summary>
+        [NotNull] public readonly string Player;
+    }
+
+    /// <summary>
+    /// Message passed from the client with the swordMsg to declare where they want to use it.
+    /// Used for the throne expansion.
+    /// </summary>
+    public readonly struct SwordMsg
+    {
+        /// <summary>
+        /// Name of the area in which the player wants to use the sword in battle.
+        /// </summary>
+        [NotNull] public readonly string Area;
+
+        /// <summary>
+        /// Index of the battle in which to use the sword, in case of several battles in the area.
+        /// </summary>
+        public readonly int BattleIndex;
+    }
+
+    /// <summary>
+    /// Message passed from the client with the ravenMsg when they want to spy on another player's orders.
+    /// Used for the throne expansion.
+    /// </summary>
+    public readonly struct RavenMsg
+    {
+        /// <summary>
+        /// ID of the player on whom to spy.
+        /// </summary>
+        [NotNull] public readonly string Player;
+    }
+}

--- a/Assets/Scripts/Api/Messages/GameMessages.cs.meta
+++ b/Assets/Scripts/Api/Messages/GameMessages.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af54a6427b55fd741859b8665d34051b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Api/Messages/LobbyMessages.cs
+++ b/Assets/Scripts/Api/Messages/LobbyMessages.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace Immerse.BfhClient.Api.Messages
+{
+    /// <summary>
+    /// Message sent from server when an error occurs.
+    /// </summary>
+    public readonly struct ErrorMsg
+    {
+        /// <summary>
+        /// The error message.
+        /// </summary>
+        [NotNull] public readonly string Error;
+    }
+
+    /// <summary>
+    /// Message sent from server to all clients when a player's status changes.
+    /// </summary>
+    public readonly struct PlayerStatusMsg
+    {
+        /// <summary>
+        /// The user's chosen display name.
+        /// </summary>
+        [NotNull] public readonly string Username;
+
+        /// <summary>
+        /// The user's selected game ID.
+        /// Null if not selected yet.
+        /// </summary>
+        [CanBeNull] public readonly string GameID;
+
+        /// <summary>
+        /// Whether the user is ready to start the game.
+        /// </summary>
+        public readonly bool Ready;
+    }
+
+    /// <summary>
+    /// Message sent to a player when they join a lobby, to inform them about other players.
+    /// </summary>
+    public readonly struct LobbyJoinedMsg
+    {
+        /// <summary>
+        /// IDs that the player may select from for this lobby's game.
+        /// Returns all game IDs, though some may already be taken by other players in the lobby.
+        /// </summary>
+        [NotNull] public readonly List<string> GameIDs;
+
+        /// <summary>
+        /// Info about each other player in the lobby.
+        /// </summary>
+        [NotNull] public readonly List<PlayerStatusMsg> PlayerStatuses;
+    }
+
+    /// <summary>
+    /// Message sent from client when they want to select a game ID.
+    /// </summary>
+    public readonly struct SelectGameIDMsg
+    {
+        /// <summary>
+        /// The ID that the player wants to select for the game.
+        /// Will be rejected if already selected by another player.
+        /// </summary>
+        [NotNull] public readonly string GameID;
+    }
+
+    /// <summary>
+    /// Message sent from client to mark themselves as ready to start the game.
+    /// Requires game ID being selected.
+    /// </summary>
+    public readonly struct ReadyMsg
+    {
+        /// <summary>
+        /// Whether the player is ready to start the game.
+        /// </summary>
+        public readonly bool Ready;
+    }
+
+    /// <summary>
+    /// Message sent from a player when the lobby wants to start the game.
+    /// Requires that all players are ready.
+    /// </summary>
+    public readonly struct StartGameMsg
+    { }
+}

--- a/Assets/Scripts/Api/Messages/LobbyMessages.cs.meta
+++ b/Assets/Scripts/Api/Messages/LobbyMessages.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8fbbf076740bcfb46a127e044b8ddea2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Api/Messages/MessageType.cs
+++ b/Assets/Scripts/Api/Messages/MessageType.cs
@@ -1,0 +1,120 @@
+namespace Immerse.BfhClient.Api.Messages
+{
+    /// <summary>
+    /// <para>
+    /// IDs for the types of messages sent between client and server.
+    /// Each ID corresponds to a message struct in <see cref="Immerse.BfhClient.Api.Messages"/>,
+    /// with the same name but suffixed with "Msg".
+    /// </para>
+    ///
+    /// <para>
+    /// Message types are used as keys in the JSON messages to and from the server.
+    /// Every message has the following format, where messageID is one of the
+    /// <see cref="Immerse.BfhClient.Api.Messages.MessageType"/> constants, and
+    /// {...message} is the corresponding "...Msg" struct in <see cref="Immerse.BfhClient.Api.Messages"/>.
+    /// <code>
+    /// {
+    ///     "[messageID]": {...message}
+    /// }
+    /// </code>
+    /// </para>
+    /// </summary>
+    ///
+    /// <example>
+    /// <see cref="Immerse.BfhClient.Api.Messages.MessageType.SupportRequest"/> is the message ID for
+    /// <see cref="Immerse.BfhClient.Api.Messages.SupportRequestMsg"/>.
+    /// The message looks like this when coming from the server:
+    /// <code>
+    /// {
+    ///     "supportRequest": {
+    ///         "supportingArea": "Calis",
+    ///         "supportablePlayers": ["red", "green"]
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public static class MessageType
+    {
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.ErrorMsg"/>.
+        /// </summary>
+        public const string Error = "error";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.PlayerStatusMsg"/>.
+        /// </summary>
+        public const string PlayerStatus = "playerStatus";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.LobbyJoinedMsg"/>.
+        /// </summary>
+        public const string LobbyJoined = "lobbyJoined";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.SelectGameIDMsg"/>.
+        /// </summary>
+        public const string SelectGameID = "selectGameId";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.ReadyMsg"/>.
+        /// </summary>
+        public const string Ready = "ready";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.StartGameMsg"/>.
+        /// </summary>
+        public const string StartGame = "startGame";
+
+        public const string SupportRequest = "supportRequest";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.OrderRequestMsg"/>.
+        /// </summary>
+        public const string OrderRequest = "orderRequest";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.OrdersReceivedMsg"/>.
+        /// </summary>
+        public const string OrdersReceived = "ordersReceived";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.OrdersConfirmationMsg"/>.
+        /// </summary>
+        public const string OrdersConfirmation = "ordersConfirmation";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.BattleResultsMsg"/>.
+        /// </summary>
+        public const string BattleResults = "battleResults";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.WinnerMsg"/>.
+        /// </summary>
+        public const string Winner = "winner";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.SubmitOrdersMsg"/>.
+        /// </summary>
+        public const string SubmitOrders = "submitOrders";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.GiveSupportMsg"/>.
+        /// </summary>
+        public const string GiveSupport = "giveSupport";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.WinterVoteMsg"/>.
+        /// </summary>
+        public const string WinterVote = "winterVote";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.SwordMsg"/>.
+        /// </summary>
+        public const string Sword = "swordMsg";
+
+        /// <summary>
+        /// Message ID for <see cref="Immerse.BfhClient.Api.Messages.RavenMsg"/>.
+        /// </summary>
+        public const string Raven = "raven";
+    }
+}

--- a/Assets/Scripts/Api/Messages/MessageType.cs.meta
+++ b/Assets/Scripts/Api/Messages/MessageType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 689dcd0bf27c8134981da95faf71d63c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Changes

- add `Api` namespace for everything related to communication with the server
- add `Api.Messages` for messages types sent to and from the server
  - adapted from [`lobby/messages.go`](https://github.com/hermannm/bfh-server/blob/main/lobby/messages.go) and [`game/messages/messages.go`](https://github.com/hermannm/bfh-server/blob/main/game/messages/messages.go) on the server
- add `Api.GameTypes` for game types used in messages from the server
  - adapted from [`game/board/types.go`](https://github.com/hermannm/bfh-server/blob/main/game/board/types.go) on the server

### Linked issues

- #15