### PR TITLE
api: change `ApiClient` to expose events for received messages

### DIFF
--- a/Assets/Scripts/Api/ApiClient.cs
+++ b/Assets/Scripts/Api/ApiClient.cs
@@ -151,7 +151,15 @@ namespace Immerse.BfhClient.Api
 
         private void Awake()
         {
-            Instance = this;
+            if (Instance is null)
+            {
+                Instance = this;
+                DontDestroyOnLoad(gameObject);
+            }
+            else if (Instance != this)
+            {
+                Destroy(gameObject);
+            }
         }
 
         private void Update()

--- a/Assets/Scripts/Api/ApiClient.cs
+++ b/Assets/Scripts/Api/ApiClient.cs
@@ -45,6 +45,11 @@ namespace Immerse.BfhClient.Api
         public event Action<SupportRequestMessage> ReceivedSupportRequestMessage;
 
         /// <summary>
+        /// Event that is triggered when server sends a <see cref="Messages.GiveSupportMessage"/>.
+        /// </summary>
+        public event Action<GiveSupportMessage> ReceivedGiveSupportMessage;
+
+        /// <summary>
         /// Event that is triggered when server sends an <see cref="Messages.OrderRequestMessage"/>.
         /// </summary>
         public event Action<OrderRequestMessage> ReceivedOrderRequestMessage;
@@ -155,6 +160,7 @@ namespace Immerse.BfhClient.Api
             TriggerEventIfMessageReceived(ReceivedPlayerStatusMessage, _messageReceiver.PlayerStatusMessages);
             TriggerEventIfMessageReceived(ReceivedLobbyJoinedMessage, _messageReceiver.LobbyJoinedMessages);
             TriggerEventIfMessageReceived(ReceivedSupportRequestMessage, _messageReceiver.SupportRequestMessages);
+            TriggerEventIfMessageReceived(ReceivedGiveSupportMessage, _messageReceiver.GiveSupportMessages);
             TriggerEventIfMessageReceived(ReceivedOrderRequestMessage, _messageReceiver.OrderRequestMessages);
             TriggerEventIfMessageReceived(ReceivedOrdersReceivedMessage, _messageReceiver.OrdersReceivedMessages);
             TriggerEventIfMessageReceived(ReceivedOrdersConfirmationMessage, _messageReceiver.OrdersConfirmationMessages);

--- a/Assets/Scripts/Api/ApiClient.cs
+++ b/Assets/Scripts/Api/ApiClient.cs
@@ -1,29 +1,73 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Immerse.BfhClient.Api.GameTypes;
 using Immerse.BfhClient.Api.Messages;
+using UnityEngine;
 
 namespace Immerse.BfhClient.Api
 {
     /// <summary>
     /// WebSocket client that connects to the game server.
-    /// Provides methods for sending and receiving game and lobby messages.
+    /// Provides methods for sending messages to the server, and events that are triggered when messages are received
+    /// from the server.
     /// Sending and receiving are no-ops until <see cref="ApiClient.Connect"/> is called.
     /// </summary>
-    public class ApiClient
+    public class ApiClient : MonoBehaviour
     {
-        private readonly ClientWebSocket _connection;
+        public static ApiClient Instance { get; private set; }
 
+        private readonly ClientWebSocket _connection = new();
         private MessageSender _messageSender;
         private MessageReceiver _messageReceiver;
 
-        public ApiClient()
-        {
-            _connection = new ClientWebSocket();
-        }
+        /// <summary>
+        /// Event that is triggered when server sends an <see cref="Messages.ErrorMessage"/>.
+        /// </summary>
+        public event Action<ErrorMessage> ReceivedErrorMessage;
+
+        /// <summary>
+        /// Event that is triggered when server sends a <see cref="Messages.PlayerStatusMessage"/>.
+        /// </summary>
+        public event Action<PlayerStatusMessage> ReceivedPlayerStatusMessage;
+
+        /// <summary>
+        /// Event that is triggered when server sends a <see cref="Messages.LobbyJoinedMessage"/>.
+        /// </summary>
+        public event Action<LobbyJoinedMessage> ReceivedLobbyJoinedMessage;
+
+        /// <summary>
+        /// Event that is triggered when server sends a <see cref="Messages.SupportRequestMessage"/>.
+        /// </summary>
+        public event Action<SupportRequestMessage> ReceivedSupportRequestMessage;
+
+        /// <summary>
+        /// Event that is triggered when server sends an <see cref="Messages.OrderRequestMessage"/>.
+        /// </summary>
+        public event Action<OrderRequestMessage> ReceivedOrderRequestMessage;
+
+        /// <summary>
+        /// Event that is triggered when server sends an <see cref="Messages.OrdersReceivedMessage"/>.
+        /// </summary>
+        public event Action<OrdersReceivedMessage> ReceivedOrdersReceivedMessage;
+
+        /// <summary>
+        /// Event that is triggered when server sends an <see cref="Messages.OrdersConfirmationMessage"/>.
+        /// </summary>
+        public event Action<OrdersConfirmationMessage> ReceivedOrdersConfirmationMessage;
+
+        /// <summary>
+        /// Event that is triggered when server sends a <see cref="Messages.BattleResultsMessage"/>.
+        /// </summary>
+        public event Action<BattleResultsMessage> ReceivedBattleResultsMessage;
+
+        /// <summary>
+        /// Event that is triggered when server sends a <see cref="Messages.WinnerMessage"/>.
+        /// </summary>
+        public event Action<WinnerMessage> ReceivedWinnerMessage;
 
         /// <summary>
         /// Connects the API client to a server at the given URI.
@@ -100,157 +144,31 @@ namespace Immerse.BfhClient.Api
             _messageSender?.SendMessage(MessageID.Raven, new RavenMessage(player));
         }
 
-        /// <summary>
-        /// Checks if the server has sent an <see cref="Messages.ErrorMessage"/>.
-        /// If it has, returns true and puts the message in the given out parameter.
-        /// Otherwise returns false.
-        /// </summary>
-        public bool TryReceiveErrorMessage(out ErrorMessage message)
+        private void Awake()
         {
-            // ReSharper disable once InvertIf
-            if (_messageReceiver is null)
-            {
-                message = default;
-                return false;
-            }
-
-            return _messageReceiver.ErrorMessages.TryDequeue(out message);
+            Instance = this;
         }
 
-        /// <summary>
-        /// Checks if the server has sent a <see cref="PlayerStatusMessage"/>.
-        /// If it has, returns true and puts the message in the given out parameter.
-        /// Otherwise returns false.
-        /// </summary>
-        public bool TryReceivePlayerStatusMessage(out PlayerStatusMessage message)
+        private void Update()
         {
-            // ReSharper disable once InvertIf
-            if (_messageReceiver is null)
-            {
-                message = default;
-                return false;
-            }
-
-            return _messageReceiver.PlayerStatusMessages.TryDequeue(out message);
+            TriggerEventIfMessageReceived(ReceivedErrorMessage, _messageReceiver.ErrorMessages);
+            TriggerEventIfMessageReceived(ReceivedPlayerStatusMessage, _messageReceiver.PlayerStatusMessages);
+            TriggerEventIfMessageReceived(ReceivedLobbyJoinedMessage, _messageReceiver.LobbyJoinedMessages);
+            TriggerEventIfMessageReceived(ReceivedSupportRequestMessage, _messageReceiver.SupportRequestMessages);
+            TriggerEventIfMessageReceived(ReceivedOrderRequestMessage, _messageReceiver.OrderRequestMessages);
+            TriggerEventIfMessageReceived(ReceivedOrdersReceivedMessage, _messageReceiver.OrdersReceivedMessages);
+            TriggerEventIfMessageReceived(ReceivedOrdersConfirmationMessage, _messageReceiver.OrdersConfirmationMessages);
+            TriggerEventIfMessageReceived(ReceivedBattleResultsMessage, _messageReceiver.BattleResultsMessages);
+            TriggerEventIfMessageReceived(ReceivedWinnerMessage, _messageReceiver.WinnerMessages);
         }
 
-        /// <summary>
-        /// Checks if the server has sent a <see cref="LobbyJoinedMessage"/>.
-        /// If it has, returns true and puts the message in the given out parameter.
-        /// Otherwise returns false.
-        /// </summary>
-        public bool TryReceiveLobbyJoinedMessage(out LobbyJoinedMessage message)
-        {
-            // ReSharper disable once InvertIf
-            if (_messageReceiver is null)
+        private static void TriggerEventIfMessageReceived<TMessage>(
+            Action<TMessage> receivedMessageEvent, ConcurrentQueue<TMessage> messageQueue
+        ) {
+            if (messageQueue.TryDequeue(out var message))
             {
-                message = default;
-                return false;
+                receivedMessageEvent?.Invoke(message);
             }
-
-            return _messageReceiver.LobbyJoinedMessages.TryDequeue(out message);
-        }
-
-        /// <summary>
-        /// Checks if the server has sent a <see cref="SupportRequestMessage"/>.
-        /// If it has, returns true and puts the message in the given out parameter.
-        /// Otherwise returns false.
-        /// </summary>
-        public bool TryReceiveSupportRequestMessage(out SupportRequestMessage message)
-        {
-            // ReSharper disable once InvertIf
-            if (_messageReceiver is null)
-            {
-                message = default;
-                return false;
-            }
-
-            return _messageReceiver.SupportRequestMessages.TryDequeue(out message);
-        }
-
-        /// <summary>
-        /// Checks if the server has sent an <see cref="OrderRequestMessage"/>.
-        /// If it has, returns true and puts the message in the given out parameter.
-        /// Otherwise returns false.
-        /// </summary>
-        public bool TryReceiveOrderRequestMessage(out OrderRequestMessage message)
-        {
-            // ReSharper disable once InvertIf
-            if (_messageReceiver is null)
-            {
-                message = default;
-                return false;
-            }
-
-            return _messageReceiver.OrderRequestMessages.TryDequeue(out message);
-        }
-
-        /// <summary>
-        /// Checks if the server has sent an <see cref="OrdersReceivedMessage"/>.
-        /// If it has, returns true and puts the message in the given out parameter.
-        /// Otherwise returns false.
-        /// </summary>
-        public bool TryReceiveOrdersReceivedMessage(out OrdersReceivedMessage message)
-        {
-            // ReSharper disable once InvertIf
-            if (_messageReceiver is null)
-            {
-                message = default;
-                return false;
-            }
-
-            return _messageReceiver.OrdersReceivedMessages.TryDequeue(out message);
-        }
-
-        /// <summary>
-        /// Checks if the server has sent an <see cref="OrdersConfirmationMessage"/>.
-        /// If it has, returns true and puts the message in the given out parameter.
-        /// Otherwise returns false.
-        /// </summary>
-        public bool TryReceiveOrdersConfirmationMessage(out OrdersConfirmationMessage message)
-        {
-            // ReSharper disable once InvertIf
-            if (_messageReceiver is null)
-            {
-                message = default;
-                return false;
-            }
-
-            return _messageReceiver.OrdersConfirmationMessages.TryDequeue(out message);
-        }
-
-        /// <summary>
-        /// Checks if the server has sent a <see cref="BattleResultsMessage"/>.
-        /// If it has, returns true and puts the message in the given out parameter.
-        /// Otherwise returns false.
-        /// </summary>
-        public bool TryReceiveBattleResultsMessage(out BattleResultsMessage message)
-        {
-            // ReSharper disable once InvertIf
-            if (_messageReceiver is null)
-            {
-                message = default;
-                return false;
-            }
-
-            return _messageReceiver.BattleResultsMessages.TryDequeue(out message);
-        }
-
-        /// <summary>
-        /// Checks if the server has sent a <see cref="WinnerMessage"/>.
-        /// If it has, returns true and puts the message in the given out parameter.
-        /// Otherwise returns false.
-        /// </summary>
-        public bool TryReceiveWinnerMessage(out WinnerMessage message)
-        {
-            // ReSharper disable once InvertIf
-            if (_messageReceiver is null)
-            {
-                message = default;
-                return false;
-            }
-
-            return _messageReceiver.WinnerMessages.TryDequeue(out message);
         }
     }
 }

--- a/Assets/Scripts/Api/MessageReceiver.cs
+++ b/Assets/Scripts/Api/MessageReceiver.cs
@@ -33,6 +33,7 @@ namespace Immerse.BfhClient.Api
         public readonly ConcurrentQueue<PlayerStatusMessage> PlayerStatusMessages = new();
         public readonly ConcurrentQueue<LobbyJoinedMessage> LobbyJoinedMessages = new();
         public readonly ConcurrentQueue<SupportRequestMessage> SupportRequestMessages = new();
+        public readonly ConcurrentQueue<GiveSupportMessage> GiveSupportMessages = new();
         public readonly ConcurrentQueue<OrderRequestMessage> OrderRequestMessages = new();
         public readonly ConcurrentQueue<OrdersReceivedMessage> OrdersReceivedMessages = new();
         public readonly ConcurrentQueue<OrdersConfirmationMessage> OrdersConfirmationMessages = new();
@@ -138,6 +139,9 @@ namespace Immerse.BfhClient.Api
                     break;
                 case MessageID.SupportRequest:
                     DeserializeAndEnqueue(serializedMessage, SupportRequestMessages);
+                    break;
+                case MessageID.GiveSupport:
+                    DeserializeAndEnqueue(serializedMessage, GiveSupportMessages);
                     break;
                 case MessageID.OrderRequest:
                     DeserializeAndEnqueue(serializedMessage, OrderRequestMessages);

--- a/Assets/Scripts/Api/MessageReceiver.cs
+++ b/Assets/Scripts/Api/MessageReceiver.cs
@@ -24,35 +24,24 @@ namespace Immerse.BfhClient.Api
     /// <remarks>
     /// Implementation based on https://www.patrykgalach.com/2019/11/11/implementing-websocket-in-unity/.
     /// </remarks>
-    public class MessageReceiver
+    internal class MessageReceiver
     {
         private readonly ClientWebSocket _connection;
         private readonly Thread _receiveThread;
 
-        public readonly ConcurrentQueue<ErrorMessage> ErrorMessages;
-        public readonly ConcurrentQueue<PlayerStatusMessage> PlayerStatusMessages;
-        public readonly ConcurrentQueue<LobbyJoinedMessage> LobbyJoinedMessages;
-        public readonly ConcurrentQueue<SupportRequestMessage> SupportRequestMessages;
-        public readonly ConcurrentQueue<OrderRequestMessage> OrderRequestMessages;
-        public readonly ConcurrentQueue<OrdersReceivedMessage> OrdersReceivedMessages;
-        public readonly ConcurrentQueue<OrdersConfirmationMessage> OrdersConfirmationMessages;
-        public readonly ConcurrentQueue<BattleResultsMessage> BattleResultsMessages;
-        public readonly ConcurrentQueue<WinnerMessage> WinnerMessages;
+        public readonly ConcurrentQueue<ErrorMessage> ErrorMessages = new();
+        public readonly ConcurrentQueue<PlayerStatusMessage> PlayerStatusMessages = new();
+        public readonly ConcurrentQueue<LobbyJoinedMessage> LobbyJoinedMessages = new();
+        public readonly ConcurrentQueue<SupportRequestMessage> SupportRequestMessages = new();
+        public readonly ConcurrentQueue<OrderRequestMessage> OrderRequestMessages = new();
+        public readonly ConcurrentQueue<OrdersReceivedMessage> OrdersReceivedMessages = new();
+        public readonly ConcurrentQueue<OrdersConfirmationMessage> OrdersConfirmationMessages = new();
+        public readonly ConcurrentQueue<BattleResultsMessage> BattleResultsMessages = new();
+        public readonly ConcurrentQueue<WinnerMessage> WinnerMessages = new();
 
         public MessageReceiver(ClientWebSocket connection)
         {
             _connection = connection;
-
-            ErrorMessages = new ConcurrentQueue<ErrorMessage>();
-            PlayerStatusMessages = new ConcurrentQueue<PlayerStatusMessage>();
-            LobbyJoinedMessages = new ConcurrentQueue<LobbyJoinedMessage>();
-            SupportRequestMessages = new ConcurrentQueue<SupportRequestMessage>();
-            OrderRequestMessages = new ConcurrentQueue<OrderRequestMessage>();
-            OrdersReceivedMessages = new ConcurrentQueue<OrdersReceivedMessage>();
-            OrdersConfirmationMessages = new ConcurrentQueue<OrdersConfirmationMessage>();
-            BattleResultsMessages = new ConcurrentQueue<BattleResultsMessage>();
-            WinnerMessages = new ConcurrentQueue<WinnerMessage>();
-
             _receiveThread = new Thread(ReceiveMessagesIntoQueues);
         }
 

--- a/Assets/Scripts/Api/MessageSender.cs
+++ b/Assets/Scripts/Api/MessageSender.cs
@@ -18,7 +18,7 @@ namespace Immerse.BfhClient.Api
     /// <remarks>
     /// Implementation based on https://www.patrykgalach.com/2019/11/11/implementing-websocket-in-unity/.
     /// </remarks>
-    public class MessageSender
+    internal class MessageSender
     {
         private readonly ClientWebSocket _connection;
         private readonly Thread _sendThread;


### PR DESCRIPTION
### Changes

- replace `TryReceive...Message` methods with `Received...Message` events in `ApiClient`
- make `ApiClient` into a singleton `MonoBehaviour`, checking for received messages on every `Update`
- change visibility `MessageReceiver` and `MessageSender` to `internal`, to avoid unnecessarily exposing them
- add handling of received `GiveSupport` messages (missed previously)

### Rationale

- Changing message receiving from using methods to using events allows two things:
  - Multiple independent message handlers can subscribe to the same message type
  - Message handlers can avoid checking for messages in their own `Update` methods, instead just registering a message handler on the `ApiClient`
- Making `ApiClient` a singleton `MonoBehaviour` gives it control over its lifetime (as opposed to putting it in another class, e.g. a `GameManager`), which is important since we want to maintain a single connection to the server

### Linked issues

- Makes #26 redundant for now, if we go for the `ApiClient` singleton implementation