### PR TITLE
api: remove readonly from message and game type fields

### DIFF
--- a/Assets/Scripts/Api/GameTypes/Battle.cs
+++ b/Assets/Scripts/Api/GameTypes/Battle.cs
@@ -8,7 +8,7 @@ namespace Immerse.BfhClient.Api.GameTypes
     /// Results of a battle from conflicting move orders, an attempt to conquer a neutral area,
     /// or an attempt to cross a danger zone.
     /// </summary>
-    public readonly struct Battle
+    public struct Battle
     {
         /// <summary>
         /// The dice and modifier results of the battle.
@@ -17,13 +17,13 @@ namespace Immerse.BfhClient.Api.GameTypes
         /// </summary>
         [JsonProperty("results", Required = Required.Always)]
         [NotNull]
-        public readonly List<Result> Results;
+        public List<Result> Results;
 
         /// <summary>
         /// In case of danger zone crossing: name of the danger zone.
         /// </summary>
         [JsonProperty("dangerZone")]
         [CanBeNull]
-        public readonly string DangerZone;
+        public string DangerZone;
     }
 }

--- a/Assets/Scripts/Api/GameTypes/Modifier.cs
+++ b/Assets/Scripts/Api/GameTypes/Modifier.cs
@@ -6,7 +6,7 @@ namespace Immerse.BfhClient.Api.GameTypes
     /// <summary>
     /// A typed number that adds to a player's result in a battle.
     /// </summary>
-    public readonly struct Modifier
+    public struct Modifier
     {
         /// <summary>
         /// The source of the modifier.
@@ -14,20 +14,20 @@ namespace Immerse.BfhClient.Api.GameTypes
         /// </summary>
         [JsonProperty("type", Required = Required.Always)]
         [NotNull]
-        public readonly string Type;
+        public string Type;
 
         /// <summary>
         /// The positive or negative number that modifies the result total.
         /// </summary>
         [JsonProperty("value", Required = Required.Always)]
-        public readonly int Value;
+        public int Value;
 
         /// <summary>
         /// If modifier was from a support: the supporting player.
         /// </summary>
         [JsonProperty("supportingPlayer")]
         [CanBeNull]
-        public readonly string SupportingPlayer;
+        public string SupportingPlayer;
     }
 
     /// <summary>

--- a/Assets/Scripts/Api/GameTypes/Order.cs
+++ b/Assets/Scripts/Api/GameTypes/Order.cs
@@ -6,7 +6,7 @@ namespace Immerse.BfhClient.Api.GameTypes
     /// <summary>
     /// An order submitted by a player for one of their units in a given round.
     /// </summary>
-    public readonly struct Order
+    public struct Order
     {
         /// <summary>
         /// The type of order submitted. Restricted by unit type and region.
@@ -14,28 +14,28 @@ namespace Immerse.BfhClient.Api.GameTypes
         /// </summary>
         [JsonProperty("type", Required = Required.Always)]
         [NotNull]
-        public readonly string Type;
+        public string Type;
 
         /// <summary>
         /// The player submitting the order.
         /// </summary>
         [JsonProperty("player", Required = Required.Always)]
         [NotNull]
-        public readonly string Player;
+        public string Player;
 
         /// <summary>
         /// Name of the region where the order is placed.
         /// </summary>
         [JsonProperty("origin", Required = Required.Always)]
         [NotNull]
-        public readonly string Origin;
+        public string Origin;
 
         /// <summary>
         /// For move and support orders: name of destination region.
         /// </summary>
         [JsonProperty("destination")]
         [CanBeNull]
-        public readonly string Destination;
+        public string Destination;
 
         /// <summary>
         /// For move orders with horse units: optional name of second destination region to move to if the first
@@ -43,14 +43,14 @@ namespace Immerse.BfhClient.Api.GameTypes
         /// </summary>
         [JsonProperty("secondDestination")]
         [CanBeNull]
-        public readonly string SecondDestination;
+        public string SecondDestination;
 
         /// <summary>
         /// For move orders: name of DangerZone the order tries to pass through, if any.
         /// </summary>
         [JsonProperty("via")]
         [CanBeNull]
-        public readonly string Via;
+        public string Via;
 
         /// <summary>
         /// For build orders: type of unit to build.
@@ -58,7 +58,7 @@ namespace Immerse.BfhClient.Api.GameTypes
         /// </summary>
         [JsonProperty("build")]
         [CanBeNull]
-        public readonly string Build;
+        public string Build;
     }
 
     /// <summary>

--- a/Assets/Scripts/Api/GameTypes/Result.cs
+++ b/Assets/Scripts/Api/GameTypes/Result.cs
@@ -7,33 +7,33 @@ namespace Immerse.BfhClient.Api.GameTypes
     /// <summary>
     /// Dice and modifier result for a battle.
     /// </summary>
-    public readonly struct Result
+    public struct Result
     {
         /// <summary>
         /// The sum of the dice roll and modifiers.
         /// </summary>
         [JsonProperty("total", Required = Required.Always)]
-        public readonly int Total;
+        public int Total;
 
         /// <summary>
         /// The modifiers comprising the result, including the dice roll.
         /// </summary>
         [JsonProperty("parts", Required = Required.Always)]
         [NotNull]
-        public readonly List<Modifier> Parts;
+        public List<Modifier> Parts;
 
         /// <summary>
         /// If result of a move order to the battle: the move order in question.
         /// </summary>
         [JsonProperty("move")]
         [CanBeNull]
-        public readonly Order? Move;
+        public Order? Move;
 
         /// <summary>
         /// If result of a defending unit in a region: the name of the region.
         /// </summary>
         [JsonProperty("defenderRegion")]
         [CanBeNull]
-        public readonly string DefenderRegion;
+        public string DefenderRegion;
     }
 }

--- a/Assets/Scripts/Api/GameTypes/Unit.cs
+++ b/Assets/Scripts/Api/GameTypes/Unit.cs
@@ -6,7 +6,7 @@ namespace Immerse.BfhClient.Api.GameTypes
     /// <summary>
     /// A player unit on the board.
     /// </summary>
-    public readonly struct Unit
+    public struct Unit
     {
         /// <summary>
         /// Affects how the unit moves and its battle capabilities.
@@ -14,14 +14,14 @@ namespace Immerse.BfhClient.Api.GameTypes
         /// </summary>
         [JsonProperty("type", Required = Required.Always)]
         [NotNull]
-        public readonly string Type;
+        public string Type;
 
         /// <summary>
         /// The player owning the unit.
         /// </summary>
         [JsonProperty("player", Required = Required.Always)]
         [NotNull]
-        public readonly string Player;
+        public string Player;
     }
 
     /// <summary>

--- a/Assets/Scripts/Api/Messages/GameMessages.cs
+++ b/Assets/Scripts/Api/Messages/GameMessages.cs
@@ -8,106 +8,106 @@ namespace Immerse.BfhClient.Api.Messages
     /// <summary>
     /// Message sent from server when asking a supporting player who to support in an embattled region.
     /// </summary>
-    public readonly struct SupportRequestMessage : IReceivableMessage
+    public struct SupportRequestMessage : IReceivableMessage
     {
         /// <summary>
         /// The region from which support is asked, where the asked player should have a support order.
         /// </summary>
         [JsonProperty("supportingRegion")]
         [NotNull]
-        public readonly string SupportingRegion;
+        public string SupportingRegion;
 
         /// <summary>
         /// List of possible players to support in the battle.
         /// </summary>
         [JsonProperty("supportablePlayers")]
         [NotNull]
-        public readonly List<string> SupportablePlayers;
+        public List<string> SupportablePlayers;
     }
 
     /// <summary>
     /// Message sent from server to client to signal that client should submit orders.
     /// </summary>
-    public readonly struct OrderRequestMessage : IReceivableMessage {}
+    public struct OrderRequestMessage : IReceivableMessage {}
 
     /// <summary>
     /// Message sent from server to all clients when valid orders are received from all players.
     /// </summary>
-    public readonly struct OrdersReceivedMessage : IReceivableMessage
+    public struct OrdersReceivedMessage : IReceivableMessage
     {
         /// <summary>
         /// Maps a player's ID to their submitted orders.
         /// </summary>
         [JsonProperty("playerOrders")]
         [NotNull]
-        public readonly Dictionary<string, List<Order>> PlayerOrders;
+        public Dictionary<string, List<Order>> PlayerOrders;
     }
 
     /// <summary>
     /// Message sent from server to all clients when valid orders are received from a player.
     /// Used to show who the server is waiting for.
     /// </summary>
-    public readonly struct OrdersConfirmationMessage : IReceivableMessage
+    public struct OrdersConfirmationMessage : IReceivableMessage
     {
         /// <summary>
         /// The player who submitted orders.
         /// </summary>
         [JsonProperty("player")]
         [NotNull]
-        public readonly string Player;
+        public string Player;
     }
 
     /// <summary>
     /// Message sent from server to all clients when a battle result is calculated.
     /// </summary>
-    public readonly struct BattleResultsMessage : IReceivableMessage
+    public struct BattleResultsMessage : IReceivableMessage
     {
         /// <summary>
         /// The relevant battle result.
         /// </summary>
         [JsonProperty("battles")]
         [NotNull]
-        public readonly List<Battle> Battles;
+        public List<Battle> Battles;
     }
 
     /// <summary>
     /// Message sent from server to all clients when the game is won.
     /// </summary>
-    public readonly struct WinnerMessage : IReceivableMessage
+    public struct WinnerMessage : IReceivableMessage
     {
         /// <summary>
         /// Player tag of the game's winner.
         /// </summary>
         [JsonProperty("winner")]
         [NotNull]
-        public readonly string Winner;
+        public string Winner;
     }
 
     /// <summary>
     /// Message sent from client when submitting orders.
     /// </summary>
-    public readonly struct SubmitOrdersMessage : ISendableMessage
+    public struct SubmitOrdersMessage : ISendableMessage
     {
         /// <summary>
         /// List of submitted orders.
         /// </summary>
         [JsonProperty("orders")]
         [NotNull]
-        public readonly List<Order> Orders;
+        public List<Order> Orders;
     }
 
     /// <summary>
     /// Message sent from client when declaring who to support with their support order.
     /// Forwarded by server to all clients to show who were given support.
     /// </summary>
-    public readonly struct GiveSupportMessage : IReceivableMessage, ISendableMessage
+    public struct GiveSupportMessage : IReceivableMessage, ISendableMessage
     {
         /// <summary>
         /// Name of the region in which the support order is placed.
         /// </summary>
         [JsonProperty("supportingRegion")]
         [NotNull]
-        public readonly string SupportingRegion;
+        public string SupportingRegion;
 
         /// <summary>
         /// ID of the player in the destination region to support.
@@ -115,54 +115,54 @@ namespace Immerse.BfhClient.Api.Messages
         /// </summary>
         [JsonProperty("supportedPlayer")]
         [CanBeNull]
-        public readonly string SupportedPlayer;
+        public string SupportedPlayer;
     }
 
     /// <summary>
     /// Message passed from the client during winter council voting.
     /// Used for the throne expansion.
     /// </summary>
-    public readonly struct WinterVoteMessage : ISendableMessage
+    public struct WinterVoteMessage : ISendableMessage
     {
         /// <summary>
         /// ID of the player that the submitting player votes for.
         /// </summary>
         [JsonProperty("player")]
         [NotNull]
-        public readonly string Player;
+        public string Player;
     }
 
     /// <summary>
     /// Message passed from the client with the swordMsg to declare where they want to use it.
     /// Used for the throne expansion.
     /// </summary>
-    public readonly struct SwordMessage : ISendableMessage
+    public struct SwordMessage : ISendableMessage
     {
         /// <summary>
         /// Name of the region in which the player wants to use the sword in battle.
         /// </summary>
         [JsonProperty("region")]
         [NotNull]
-        public readonly string Region;
+        public string Region;
 
         /// <summary>
         /// Index of the battle in which to use the sword, in case of several battles in the region.
         /// </summary>
         [JsonProperty("battleIndex")]
-        public readonly int BattleIndex;
+        public int BattleIndex;
     }
 
     /// <summary>
     /// Message passed from the client with the ravenMsg when they want to spy on another player's orders.
     /// Used for the throne expansion.
     /// </summary>
-    public readonly struct RavenMessage : ISendableMessage
+    public struct RavenMessage : ISendableMessage
     {
         /// <summary>
         /// ID of the player on whom to spy.
         /// </summary>
         [JsonProperty("player")]
         [NotNull]
-        public readonly string Player;
+        public string Player;
     }
 }

--- a/Assets/Scripts/Api/Messages/LobbyMessages.cs
+++ b/Assets/Scripts/Api/Messages/LobbyMessages.cs
@@ -7,27 +7,27 @@ namespace Immerse.BfhClient.Api.Messages
     /// <summary>
     /// Message sent from server when an error occurs.
     /// </summary>
-    public readonly struct ErrorMessage : IReceivableMessage
+    public struct ErrorMessage : IReceivableMessage
     {
         /// <summary>
         /// The error message.
         /// </summary>
         [JsonProperty("error")]
         [NotNull]
-        public readonly string Error;
+        public string Error;
     }
 
     /// <summary>
     /// Message sent from server to all clients when a player's status changes.
     /// </summary>
-    public readonly struct PlayerStatusMessage : IReceivableMessage
+    public struct PlayerStatusMessage : IReceivableMessage
     {
         /// <summary>
         /// The user's chosen display name.
         /// </summary>
         [JsonProperty("username")]
         [NotNull]
-        public readonly string Username;
+        public string Username;
 
         /// <summary>
         /// The user's selected game ID.
@@ -35,19 +35,19 @@ namespace Immerse.BfhClient.Api.Messages
         /// </summary>
         [JsonProperty("gameId")]
         [CanBeNull]
-        public readonly string GameId;
+        public string GameId;
 
         /// <summary>
         /// Whether the user is ready to start the game.
         /// </summary>
         [JsonProperty("ready")]
-        public readonly bool Ready;
+        public bool Ready;
     }
 
     /// <summary>
     /// Message sent to a player when they join a lobby, to inform them about other players.
     /// </summary>
-    public readonly struct LobbyJoinedMessage : IReceivableMessage
+    public struct LobbyJoinedMessage : IReceivableMessage
     {
         /// <summary>
         /// IDs that the player may select from for this lobby's game.
@@ -55,20 +55,20 @@ namespace Immerse.BfhClient.Api.Messages
         /// </summary>
         [JsonProperty("gameIds")]
         [NotNull]
-        public readonly List<string> GameIds;
+        public List<string> GameIds;
 
         /// <summary>
         /// Info about each other player in the lobby.
         /// </summary>
         [JsonProperty("playerStatuses")]
         [NotNull]
-        public readonly List<PlayerStatusMessage> PlayerStatuses;
+        public List<PlayerStatusMessage> PlayerStatuses;
     }
 
     /// <summary>
     /// Message sent from client when they want to select a game ID.
     /// </summary>
-    public readonly struct SelectGameIdMessage : ISendableMessage
+    public struct SelectGameIdMessage : ISendableMessage
     {
         /// <summary>
         /// The ID that the player wants to select for the game.
@@ -76,25 +76,25 @@ namespace Immerse.BfhClient.Api.Messages
         /// </summary>
         [JsonProperty("gameId")]
         [NotNull]
-        public readonly string GameId;
+        public string GameId;
     }
 
     /// <summary>
     /// Message sent from client to mark themselves as ready to start the game.
     /// Requires game ID being selected.
     /// </summary>
-    public readonly struct ReadyMessage : ISendableMessage
+    public struct ReadyMessage : ISendableMessage
     {
         /// <summary>
         /// Whether the player is ready to start the game.
         /// </summary>
         [JsonProperty("ready")]
-        public readonly bool Ready;
+        public bool Ready;
     }
 
     /// <summary>
     /// Message sent from a player when the lobby wants to start the game.
     /// Requires that all players are ready.
     /// </summary>
-    public readonly struct StartGameMessage : ISendableMessage {}
+    public struct StartGameMessage : ISendableMessage {}
 }


### PR DESCRIPTION
### Changes

- remove `readonly` from fields in game type and message structs, to make instantiation easier